### PR TITLE
Refactor price feed design

### DIFF
--- a/internal/exchange/engine.go
+++ b/internal/exchange/engine.go
@@ -21,9 +21,9 @@ type Engine struct {
 // NewEngine creates a new Engine.
 func NewEngine() *Engine {
 	return &Engine{
-		bids:   make([]*types.Order, 0),
-		asks:   make([]*types.Order, 0),
-		orders: make(map[string]*types.Order),
+		bids:   []*types.Order{},
+		asks:   []*types.Order{},
+		orders: map[string]*types.Order{},
 	}
 }
 

--- a/internal/exchange/engine.go
+++ b/internal/exchange/engine.go
@@ -1,0 +1,193 @@
+package exchange
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/darthshoge/mm_hedger_go/pkg/types"
+)
+
+// Engine represents a simple order matching engine.
+type Engine struct {
+	mu     sync.Mutex
+	bids   []*types.Order
+	asks   []*types.Order
+	orders map[string]*types.Order
+}
+
+// NewEngine creates a new Engine.
+func NewEngine() *Engine {
+	return &Engine{
+		bids:   make([]*types.Order, 0),
+		asks:   make([]*types.Order, 0),
+		orders: make(map[string]*types.Order),
+	}
+}
+
+// Submit adds an order to the book and attempts to match it.
+func (e *Engine) Submit(o *types.Order) ([]*types.Trade, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	o.ID = e.randomID()
+	o.Timestamp = time.Now()
+	trades := e.matchOrder(o)
+	if o.Quantity > 0 && o.Type == types.OrderTypeLimit {
+		e.addToBook(o)
+		e.orders[o.ID] = o
+	}
+
+	return trades, nil
+}
+
+// Cancel removes an existing order from the book.
+func (e *Engine) Cancel(id string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	ord, ok := e.orders[id]
+	if !ok {
+		return false
+	}
+	switch ord.Side {
+	case types.SideBuy:
+		e.bids = removeOrder(e.bids, id)
+	case types.SideSell:
+		e.asks = removeOrder(e.asks, id)
+	}
+	delete(e.orders, id)
+	return true
+}
+
+// Match matches resting orders in the book until no more trades can occur.
+func (e *Engine) Match() []*types.Trade {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	trades := []*types.Trade{}
+	for {
+		if len(e.bids) == 0 || len(e.asks) == 0 {
+			break
+		}
+		bestBid := e.bids[0]
+		bestAsk := e.asks[0]
+		if bestBid.Price < bestAsk.Price {
+			break
+		}
+		qty := min(bestBid.Quantity, bestAsk.Quantity)
+		trade := &types.Trade{
+			ID:        e.randomID(),
+			OrderID:   bestBid.ID,
+			Side:      types.SideBuy,
+			Price:     bestAsk.Price,
+			Quantity:  qty,
+			Timestamp: time.Now(),
+		}
+		trades = append(trades, trade)
+		bestBid.Quantity -= qty
+		bestAsk.Quantity -= qty
+		if bestBid.Quantity == 0 {
+			e.bids = e.bids[1:]
+			delete(e.orders, bestBid.ID)
+		}
+		if bestAsk.Quantity == 0 {
+			e.asks = e.asks[1:]
+			delete(e.orders, bestAsk.ID)
+		}
+	}
+	return trades
+}
+
+func (e *Engine) matchOrder(o *types.Order) []*types.Trade {
+	var trades []*types.Trade
+	for o.Quantity > 0 {
+		if o.Side == types.SideBuy {
+			if len(e.asks) == 0 {
+				break
+			}
+			best := e.asks[0]
+			if o.Type == types.OrderTypeLimit && o.Price < best.Price {
+				break
+			}
+			qty := min(o.Quantity, best.Quantity)
+			trade := &types.Trade{
+				ID:        e.randomID(),
+				OrderID:   o.ID,
+				Side:      o.Side,
+				Price:     best.Price,
+				Quantity:  qty,
+				Timestamp: time.Now(),
+			}
+			trades = append(trades, trade)
+			o.Quantity -= qty
+			best.Quantity -= qty
+			if best.Quantity == 0 {
+				e.asks = e.asks[1:]
+				delete(e.orders, best.ID)
+			}
+		} else {
+			if len(e.bids) == 0 {
+				break
+			}
+			best := e.bids[0]
+			if o.Type == types.OrderTypeLimit && o.Price > best.Price {
+				break
+			}
+			qty := min(o.Quantity, best.Quantity)
+			trade := &types.Trade{
+				ID:        e.randomID(),
+				OrderID:   o.ID,
+				Side:      o.Side,
+				Price:     best.Price,
+				Quantity:  qty,
+				Timestamp: time.Now(),
+			}
+			trades = append(trades, trade)
+			o.Quantity -= qty
+			best.Quantity -= qty
+			if best.Quantity == 0 {
+				e.bids = e.bids[1:]
+				delete(e.orders, best.ID)
+			}
+		}
+	}
+	return trades
+}
+
+func (e *Engine) addToBook(o *types.Order) {
+	switch o.Side {
+	case types.SideBuy:
+		e.bids = append(e.bids, o)
+		sort.SliceStable(e.bids, func(i, j int) bool {
+			return e.bids[i].Price > e.bids[j].Price
+		})
+	case types.SideSell:
+		e.asks = append(e.asks, o)
+		sort.SliceStable(e.asks, func(i, j int) bool {
+			return e.asks[i].Price < e.asks[j].Price
+		})
+	}
+}
+
+func removeOrder(list []*types.Order, id string) []*types.Order {
+	for i, o := range list {
+		if o.ID == id {
+			return append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
+}
+
+func (e *Engine) randomID() string {
+	return fmt.Sprintf("%d", rand.Int63())
+}
+
+func min(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/exchange/engine_test.go
+++ b/internal/exchange/engine_test.go
@@ -1,0 +1,53 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/darthshoge/mm_hedger_go/pkg/types"
+)
+
+func TestEngineSubmitMatch(t *testing.T) {
+	e := NewEngine()
+
+	sell := &types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 101, Quantity: 1}
+	if trades, _ := e.Submit(sell); len(trades) != 0 {
+		t.Fatalf("expected no trades on first submit")
+	}
+
+	buy := &types.Order{Side: types.SideBuy, Type: types.OrderTypeLimit, Price: 102, Quantity: 1}
+	trades, _ := e.Submit(buy)
+	if len(trades) != 1 {
+		t.Fatalf("expected one trade, got %d", len(trades))
+	}
+	if trades[0].Price != 101 {
+		t.Fatalf("expected price 101, got %f", trades[0].Price)
+	}
+	if len(e.bids) != 0 || len(e.asks) != 0 {
+		t.Fatalf("orderbook should be empty after match")
+	}
+}
+
+func TestEngineCancel(t *testing.T) {
+	e := NewEngine()
+	ord := &types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 100, Quantity: 1}
+	e.Submit(ord)
+	if !e.Cancel(ord.ID) {
+		t.Fatalf("expected cancel to succeed")
+	}
+	if len(e.asks) != 0 {
+		t.Fatalf("order should be removed")
+	}
+}
+
+func TestEngineMarketOrder(t *testing.T) {
+	e := NewEngine()
+	e.Submit(&types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 100, Quantity: 1})
+	buy := &types.Order{Side: types.SideBuy, Type: types.OrderTypeMarket, Quantity: 1}
+	trades, _ := e.Submit(buy)
+	if len(trades) != 1 {
+		t.Fatalf("expected one trade for market order")
+	}
+	if len(e.asks) != 0 {
+		t.Fatalf("orderbook should be empty")
+	}
+}

--- a/internal/exchange/engine_test.go
+++ b/internal/exchange/engine_test.go
@@ -51,3 +51,19 @@ func TestEngineMarketOrder(t *testing.T) {
 		t.Fatalf("orderbook should be empty")
 	}
 }
+
+func TestEngineOrderWithNoMatch(t *testing.T) {
+	e := NewEngine()
+	sell := &types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 100, Quantity: 1}
+	if trades, _ := e.Submit(sell); len(trades) != 0 {
+		t.Fatalf("expected no trades on first submit")
+	}
+
+	buy := &types.Order{Side: types.SideBuy, Type: types.OrderTypeLimit, Price: 99, Quantity: 1}
+	if trades, _ := e.Submit(buy); len(trades) != 0 {
+		t.Fatalf("expected no trades for unmatched order")
+	}
+	if len(e.bids) != 1 || len(e.asks) != 1 {
+		t.Fatalf("orderbook should contain one bid and one ask")
+	}
+}

--- a/internal/exchange/pricefeed.go
+++ b/internal/exchange/pricefeed.go
@@ -1,0 +1,69 @@
+package exchange
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/darthshoge/mm_hedger_go/pkg/types"
+)
+
+// PriceFeed defines the interface for generating market quotes.
+type PriceFeed interface {
+	// Step advances the feed one tick and returns a new market quote.
+	Step() *types.Quote
+}
+
+// RandomWalkFeed implements PriceFeed using a simple random walk model.
+type RandomWalkFeed struct {
+	Price float64
+	Mu    float64
+	Sigma float64
+	rand  *rand.Rand
+}
+
+// NewRandomWalkFeed returns a random walk price feed.
+func NewRandomWalkFeed(initial, mu, sigma float64) *RandomWalkFeed {
+	return &RandomWalkFeed{
+		Price: initial,
+		Mu:    mu,
+		Sigma: sigma,
+		rand:  rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Step advances the price using a random walk and returns a new quote.
+func (p *RandomWalkFeed) Step() *types.Quote {
+	p.Price += p.Mu + p.Sigma*p.rand.NormFloat64()
+	return &types.Quote{
+		Bid:       p.Price - 0.5,
+		Ask:       p.Price + 0.5,
+		BidSize:   1,
+		AskSize:   1,
+		Timestamp: time.Now(),
+	}
+}
+
+// StaticPriceFeed always returns the same price.
+type StaticPriceFeed struct {
+	Quote types.Quote
+}
+
+// NewStaticPriceFeed returns a StaticPriceFeed with the given price.
+func NewStaticPriceFeed(price float64) *StaticPriceFeed {
+	return &StaticPriceFeed{
+		Quote: types.Quote{
+			Bid:       price - 0.5,
+			Ask:       price + 0.5,
+			BidSize:   1,
+			AskSize:   1,
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// Step returns the stored quote and updates the timestamp.
+func (s *StaticPriceFeed) Step() *types.Quote {
+	s.Quote.Timestamp = time.Now()
+	q := s.Quote
+	return &q
+}

--- a/internal/exchange/pricefeed_test.go
+++ b/internal/exchange/pricefeed_test.go
@@ -16,6 +16,18 @@ func TestRandomWalkFeedStep(t *testing.T) {
 	}
 }
 
+func TestQuoteMidPrice(t *testing.T) {
+	pf := NewRandomWalkFeed(100, 1, 0)
+	q := pf.Step()
+	mid := q.MidPrice()
+	if mid != 100+1 {
+		t.Fatalf("unexpected mid price: got %f, want %f", mid, float64(100+1))
+	}
+	if q.Bid == 0 || q.Ask == 0 {
+		t.Fatalf("bid or ask should not be zero")
+	}
+}
+
 func TestStaticPriceFeed(t *testing.T) {
 	pf := NewStaticPriceFeed(50)
 	q1 := pf.Step()

--- a/internal/exchange/pricefeed_test.go
+++ b/internal/exchange/pricefeed_test.go
@@ -1,0 +1,30 @@
+package exchange
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRandomWalkFeedStep(t *testing.T) {
+	pf := NewRandomWalkFeed(100, 1, 0)
+	q := pf.Step()
+	if q.Bid != 100+1-0.5 {
+		t.Fatalf("unexpected bid price")
+	}
+	if pf.Price != 101 {
+		t.Fatalf("price not updated")
+	}
+}
+
+func TestStaticPriceFeed(t *testing.T) {
+	pf := NewStaticPriceFeed(50)
+	q1 := pf.Step()
+	if q1.Bid != 49.5 || q1.Ask != 50.5 {
+		t.Fatalf("static feed returned wrong quote")
+	}
+	time.Sleep(time.Millisecond)
+	q2 := pf.Step()
+	if !q2.Timestamp.After(q1.Timestamp) {
+		t.Fatalf("timestamp not updated")
+	}
+}

--- a/pkg/types/quote.go
+++ b/pkg/types/quote.go
@@ -2,7 +2,16 @@ package types
 
 import "time"
 
-// Quote represents a market quote with bid/ask prices and sizes.
+ // Quote represents a market quote with bid/ask prices and sizes.
+
+// MidPrice returns the midpoint between Bid and Ask.
+// If either Bid or Ask is zero, it returns zero.
+func (q *Quote) MidPrice() float64 {
+	if q.Bid == 0 || q.Ask == 0 {
+		return 0
+	}
+	return (q.Bid + q.Ask) / 2
+}
 type Quote struct {
 	Bid       float64
 	Ask       float64


### PR DESCRIPTION
### Summary
Make the price feed abstraction extensible.

### Changes
- introduce `PriceFeed` interface with `Step()`
- implement `RandomWalkFeed` and `StaticPriceFeed`
- update tests for new feed types

### Tests
```bash
go vet ./...
go test -race ./...
```

### Checklist
- [ ] go vet / lint passes
- [ ] tests pass
- [ ] docs updated

------
https://chatgpt.com/codex/tasks/task_e_6848b369377883339066d1006d177d6f