### PR TITLE
Implement quote strategy

### DIFF
--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -1,0 +1,42 @@
+package strategy
+
+import "github.com/darthshoge/mm_hedger_go/pkg/types"
+
+// QuoteStrategy generates bid and ask quotes around a mid price.
+// Spread defines the half-spread from the mid price while InvSkew
+// shifts quotes based on current inventory to encourage reversion
+// towards zero.
+type QuoteStrategy struct {
+	BaseSize float64
+	Spread   float64
+	InvSkew  float64
+}
+
+// NewQuoteStrategy returns a QuoteStrategy with the provided
+// parameters.
+func NewQuoteStrategy(baseSize, spread, invSkew float64) *QuoteStrategy {
+	return &QuoteStrategy{BaseSize: baseSize, Spread: spread, InvSkew: invSkew}
+}
+
+// GenerateQuotes returns bid and ask limit orders given the current
+// mid price and inventory. Positive inventory shifts both prices down
+// while negative inventory shifts them up.
+func (s *QuoteStrategy) GenerateQuotes(mid, inventory float64) (bid, ask *types.Order) {
+	adjust := s.InvSkew * inventory
+	bidPrice := mid - s.Spread - adjust
+	askPrice := mid + s.Spread - adjust
+
+	bid = &types.Order{
+		Side:     types.SideBuy,
+		Type:     types.OrderTypeLimit,
+		Price:    bidPrice,
+		Quantity: s.BaseSize,
+	}
+	ask = &types.Order{
+		Side:     types.SideSell,
+		Type:     types.OrderTypeLimit,
+		Price:    askPrice,
+		Quantity: s.BaseSize,
+	}
+	return
+}

--- a/internal/strategy/strategy_test.go
+++ b/internal/strategy/strategy_test.go
@@ -1,0 +1,26 @@
+package strategy
+
+import "testing"
+
+func TestGenerateQuotesZeroInventory(t *testing.T) {
+	strat := NewQuoteStrategy(1, 0.5, 0.1)
+	bid, ask := strat.GenerateQuotes(100, 0)
+	if bid.Price != 99.5 {
+		t.Fatalf("bid price wrong: %f", bid.Price)
+	}
+	if ask.Price != 100.5 {
+		t.Fatalf("ask price wrong: %f", ask.Price)
+	}
+}
+
+func TestGenerateQuotesInventorySkew(t *testing.T) {
+	strat := NewQuoteStrategy(1, 0.5, 0.1)
+	bid, ask := strat.GenerateQuotes(100, 10)
+	// adjust = 1
+	if bid.Price != 98.5 {
+		t.Fatalf("bid price wrong with inventory: %f", bid.Price)
+	}
+	if ask.Price != 99.5 {
+		t.Fatalf("ask price wrong with inventory: %f", ask.Price)
+	}
+}


### PR DESCRIPTION
### Summary
Add initial quote generation logic for market making.

### Changes
- introduce `QuoteStrategy` with inventory-aware pricing
- unit tests for strategy scenarios

### Tests
```bash
make test
```

### Checklist
- [x] go vet / lint passes
- [x] tests pass
- [ ] docs updated

------
https://chatgpt.com/codex/tasks/task_e_685496b336f4833389017c94c4deb812