### PR TITLE
Implement hedge component

### DIFF
--- a/internal/hedge/hedger.go
+++ b/internal/hedge/hedger.go
@@ -1,0 +1,50 @@
+package hedge
+
+import (
+	"time"
+
+	"github.com/darthshoge/mm_hedger_go/internal/exchange"
+	"github.com/darthshoge/mm_hedger_go/pkg/types"
+)
+
+// Hedger mirrors trades executed on one exchange onto another with a fixed latency.
+// It is not thread-safe and should be used from a single goroutine.
+type Hedger struct {
+	Engine  *exchange.Engine
+	Latency time.Duration
+}
+
+// NewHedger returns a Hedger that sends orders to the given engine after the specified latency.
+func NewHedger(engine *exchange.Engine, latency time.Duration) *Hedger {
+	return &Hedger{Engine: engine, Latency: latency}
+}
+
+// Hedge submits offsetting market orders on the hedge exchange to neutralize the provided trades.
+// Returns the trades generated on the hedge exchange.
+func (h *Hedger) Hedge(trades []*types.Trade) ([]*types.Trade, error) {
+	var hedgeTrades []*types.Trade
+	for _, t := range trades {
+		// opposite side of original trade
+		side := types.SideSell
+		if t.Side == types.SideSell {
+			side = types.SideBuy
+		}
+
+		order := &types.Order{
+			Side:     side,
+			Type:     types.OrderTypeMarket,
+			Quantity: t.Quantity,
+		}
+
+		if h.Latency > 0 {
+			time.Sleep(h.Latency)
+		}
+
+		ts, err := h.Engine.Submit(order)
+		if err != nil {
+			return hedgeTrades, err
+		}
+		hedgeTrades = append(hedgeTrades, ts...)
+	}
+	return hedgeTrades, nil
+}

--- a/internal/hedge/hedger_test.go
+++ b/internal/hedge/hedger_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/darthshoge/mm_hedger_go/pkg/types"
 )
 
-func TestHedgerMirrorsTrade(t *testing.T) {
+func TestHedgerMirrorsBuyTrade(t *testing.T) {
 	eng := exchange.NewEngine()
 	// provide liquidity on both sides so market orders fill
 	eng.Submit(&types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 101, Quantity: 10})
@@ -27,6 +27,31 @@ func TestHedgerMirrorsTrade(t *testing.T) {
 	}
 	if trades[0].Side != types.SideSell {
 		t.Fatalf("expected hedge side sell, got %v", trades[0].Side)
+	}
+	if time.Since(start) < time.Millisecond {
+		t.Fatalf("latency not applied")
+	}
+}
+
+func TestHedgerMirrorsSellTrade(t *testing.T) {
+	eng := exchange.NewEngine()
+	// provide liquidity on both sides so market orders fill
+	eng.Submit(&types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 101, Quantity: 10})
+	eng.Submit(&types.Order{Side: types.SideBuy, Type: types.OrderTypeLimit, Price: 99, Quantity: 10})
+
+	h := NewHedger(eng, time.Millisecond)
+	trade := &types.Trade{Side: types.SideSell, Quantity: 1, Price: 100}
+
+	start := time.Now()
+	trades, err := h.Hedge([]*types.Trade{trade})
+	if err != nil {
+		t.Fatalf("hedge returned error: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 hedge trade, got %d", len(trades))
+	}
+	if trades[0].Side != types.SideBuy {
+		t.Fatalf("expected hedge side buy, got %v", trades[0].Side)
 	}
 	if time.Since(start) < time.Millisecond {
 		t.Fatalf("latency not applied")

--- a/internal/hedge/hedger_test.go
+++ b/internal/hedge/hedger_test.go
@@ -1,0 +1,34 @@
+package hedge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/darthshoge/mm_hedger_go/internal/exchange"
+	"github.com/darthshoge/mm_hedger_go/pkg/types"
+)
+
+func TestHedgerMirrorsTrade(t *testing.T) {
+	eng := exchange.NewEngine()
+	// provide liquidity on both sides so market orders fill
+	eng.Submit(&types.Order{Side: types.SideSell, Type: types.OrderTypeLimit, Price: 101, Quantity: 10})
+	eng.Submit(&types.Order{Side: types.SideBuy, Type: types.OrderTypeLimit, Price: 99, Quantity: 10})
+
+	h := NewHedger(eng, time.Millisecond)
+	trade := &types.Trade{Side: types.SideBuy, Quantity: 1, Price: 100}
+
+	start := time.Now()
+	trades, err := h.Hedge([]*types.Trade{trade})
+	if err != nil {
+		t.Fatalf("hedge returned error: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 hedge trade, got %d", len(trades))
+	}
+	if trades[0].Side != types.SideSell {
+		t.Fatalf("expected hedge side sell, got %v", trades[0].Side)
+	}
+	if time.Since(start) < time.Millisecond {
+		t.Fatalf("latency not applied")
+	}
+}


### PR DESCRIPTION
### Summary
Add basic hedger module that mirrors trades onto a second exchange.

### Changes
- implement `Hedger` with latency configurable
- add unit test verifying hedging behaviour

### Tests
```bash
go test ./...
go test -race ./...
```

### Checklist
- [ ] go vet / lint passes
- [ ] tests pass
- [ ] docs updated

------
https://chatgpt.com/codex/tasks/task_e_685c7a82845c833380a21b377d027f3c